### PR TITLE
docs: change 'Switch instantly' to 'Launch variants instantly'

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Claude Code is powerful, but locked to Anthropic's API. **CC-MIRROR** lets you:
 
 - **Use any provider** — Z.ai's GLM models, MiniMax-M2.1, OpenRouter's 100+ models, or route to local LLMs via Claude Code Router
 - **Keep variants isolated** — Each variant has its own config, sessions, and themes
-- **Switch instantly** — Run `zai` for Z.ai, `minimax` for MiniMax, `openrouter` for OpenRouter
+- **Launch variants instantly** — Run `zai` for Z.ai, `minimax` for MiniMax, `openrouter` for OpenRouter
 
 ## Features
 


### PR DESCRIPTION
Improves clarity by avoiding confusion that users can switch models within a single session. The term 'variants' better reflects CC-MIRROR's architecture of isolated instances.

Fixes #1

---

Generated with [Claude Code](https://claude.ai/code)