### PR TITLE
feat: add Windows splash screen support for all providers

### DIFF
--- a/src/core/variant-builder/steps/WrapperStep.ts
+++ b/src/core/variant-builder/steps/WrapperStep.ts
@@ -2,7 +2,7 @@
  * WrapperStep - Writes the CLI wrapper script
  */
 
-import { writeWrapper } from '../../wrapper.js';
+import { writeWrapper, writeWindowsWrapper } from '../../wrapper.js';
 import type { BuildContext, BuildStep } from '../types.js';
 
 export class WrapperStep implements BuildStep {
@@ -10,11 +10,19 @@ export class WrapperStep implements BuildStep {
 
   execute(ctx: BuildContext): void {
     ctx.report('Writing CLI wrapper...');
-    writeWrapper(ctx.paths.wrapperPath, ctx.paths.configDir, ctx.state.binaryPath, 'node');
+    if (process.platform === 'win32') {
+      writeWindowsWrapper(ctx.paths.wrapperPath, ctx.paths.configDir, ctx.state.binaryPath, ctx.params.name);
+    } else {
+      writeWrapper(ctx.paths.wrapperPath, ctx.paths.configDir, ctx.state.binaryPath, 'node');
+    }
   }
 
   async executeAsync(ctx: BuildContext): Promise<void> {
     await ctx.report('Writing CLI wrapper...');
-    writeWrapper(ctx.paths.wrapperPath, ctx.paths.configDir, ctx.state.binaryPath, 'node');
+    if (process.platform === 'win32') {
+      writeWindowsWrapper(ctx.paths.wrapperPath, ctx.paths.configDir, ctx.state.binaryPath, ctx.params.name);
+    } else {
+      writeWrapper(ctx.paths.wrapperPath, ctx.paths.configDir, ctx.state.binaryPath, 'node');
+    }
   }
 }

--- a/src/core/variant-builder/update-steps/WrapperUpdateStep.ts
+++ b/src/core/variant-builder/update-steps/WrapperUpdateStep.ts
@@ -5,7 +5,7 @@
 import path from 'node:path';
 import { ensureDir } from '../../fs.js';
 import { expandTilde } from '../../paths.js';
-import { writeWrapper } from '../../wrapper.js';
+import { writeWrapper, writeWindowsWrapper } from '../../wrapper.js';
 import type { UpdateContext, UpdateStep } from '../types.js';
 
 export class WrapperUpdateStep implements UpdateStep {
@@ -14,16 +14,16 @@ export class WrapperUpdateStep implements UpdateStep {
   execute(ctx: UpdateContext): void {
     if (ctx.opts.settingsOnly) return;
     ctx.report('Writing CLI wrapper...');
-    this.writeWrapper(ctx);
+    this.doWriteWrapper(ctx);
   }
 
   async executeAsync(ctx: UpdateContext): Promise<void> {
     if (ctx.opts.settingsOnly) return;
     await ctx.report('Writing CLI wrapper...');
-    this.writeWrapper(ctx);
+    this.doWriteWrapper(ctx);
   }
 
-  private writeWrapper(ctx: UpdateContext): void {
+  private doWriteWrapper(ctx: UpdateContext): void {
     const { name, opts, meta } = ctx;
 
     const resolvedBin = opts.binDir ? (expandTilde(opts.binDir) ?? opts.binDir) : meta.binDir;
@@ -31,7 +31,11 @@ export class WrapperUpdateStep implements UpdateStep {
     if (resolvedBin) {
       ensureDir(resolvedBin);
       const wrapperPath = path.join(resolvedBin, name);
-      writeWrapper(wrapperPath, meta.configDir, meta.binaryPath, 'node');
+      if (process.platform === 'win32') {
+        writeWindowsWrapper(wrapperPath, meta.configDir, meta.binaryPath, name);
+      } else {
+        writeWrapper(wrapperPath, meta.configDir, meta.binaryPath, 'node');
+      }
       meta.binDir = resolvedBin;
     }
   }

--- a/src/core/wrapper.ts
+++ b/src/core/wrapper.ts
@@ -1,6 +1,229 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+// ANSI color codes for colored ASCII art (shared between bash and Windows)
+// Use single backslash so when interpolated into template string, it becomes the escape char
+const C = {
+  reset: '\x1b[0m',
+  // Zai: Gold/Amber gradient
+  zaiPrimary: '\x1b[38;5;220m',
+  zaiSecondary: '\x1b[38;5;214m',
+  zaiAccent: '\x1b[38;5;208m',
+  zaiDim: '\x1b[38;5;172m',
+  // MiniMax: Coral/Red/Orange gradient
+  mmPrimary: '\x1b[38;5;203m',
+  mmSecondary: '\x1b[38;5;209m',
+  mmAccent: '\x1b[38;5;208m',
+  mmDim: '\x1b[38;5;167m',
+  // OpenRouter: Cyan/Teal gradient
+  orPrimary: '\x1b[38;5;43m',
+  orSecondary: '\x1b[38;5;49m',
+  orAccent: '\x1b[38;5;37m',
+  orDim: '\x1b[38;5;30m',
+  // CCRouter: Sky blue gradient
+  ccrPrimary: '\x1b[38;5;39m',
+  ccrSecondary: '\x1b[38;5;45m',
+  ccrAccent: '\x1b[38;5;33m',
+  ccrDim: '\x1b[38;5;31m',
+  // Mirror: Silver/Chrome with electric blue
+  mirPrimary: '\x1b[38;5;252m',
+  mirSecondary: '\x1b[38;5;250m',
+  mirAccent: '\x1b[38;5;45m',
+  mirDim: '\x1b[38;5;243m',
+  // Default: White/Gray
+  defPrimary: '\x1b[38;5;255m',
+  defDim: '\x1b[38;5;245m',
+};
+
+/**
+ * Writes a Windows wrapper (.js + .cmd) with splash screen support for all providers
+ */
+export const writeWindowsWrapper = (
+  wrapperPath: string,
+  configDir: string,
+  binaryPath: string,
+  variantName: string
+): void => {
+  const tweakDir = path.join(path.dirname(configDir), 'tweakcc');
+  const jsPath = wrapperPath.endsWith('.cmd') ? wrapperPath.replace('.cmd', '.js') : wrapperPath + '.js';
+  const cmdPath = wrapperPath.endsWith('.cmd') ? wrapperPath : wrapperPath + '.cmd';
+
+  const jsContent = `// CC Mirror Windows Wrapper - Auto-generated
+// Supports splash screens for all providers: zai, minimax, openrouter, ccrouter, mirror
+
+const fs = require('fs');
+const path = require('path');
+const { spawn } = require('child_process');
+
+const home = process.env.USERPROFILE || process.env.HOME;
+const variantName = '${variantName}';
+const configDir = ${JSON.stringify(configDir)};
+const tweakDir = ${JSON.stringify(tweakDir)};
+const cliPath = ${JSON.stringify(binaryPath)};
+const settingsPath = path.join(configDir, 'settings.json');
+
+// Load environment from settings.json
+let env = { ...process.env };
+env.CLAUDE_CONFIG_DIR = configDir;
+env.TWEAKCC_CONFIG_DIR = tweakDir;
+
+if (fs.existsSync(settingsPath)) {
+    try {
+        const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+        if (settings.env) {
+            Object.assign(env, settings.env);
+        }
+    } catch (e) {
+        console.error('Failed to parse settings.json:', e);
+    }
+}
+
+// Check if cli.js exists
+if (!fs.existsSync(cliPath)) {
+    console.error(\`Error: Claude Code CLI not found at \${cliPath}\`);
+    console.error('Please run "npx cc-mirror update ' + variantName + '" or check your installation.');
+    process.exit(1);
+}
+
+// ANSI color codes for colored ASCII art
+const C = {
+    reset: '${C.reset}',
+    zaiPrimary: '${C.zaiPrimary}', zaiSecondary: '${C.zaiSecondary}', zaiAccent: '${C.zaiAccent}', zaiDim: '${C.zaiDim}',
+    mmPrimary: '${C.mmPrimary}', mmSecondary: '${C.mmSecondary}', mmAccent: '${C.mmAccent}', mmDim: '${C.mmDim}',
+    orPrimary: '${C.orPrimary}', orSecondary: '${C.orSecondary}', orAccent: '${C.orAccent}', orDim: '${C.orDim}',
+    ccrPrimary: '${C.ccrPrimary}', ccrSecondary: '${C.ccrSecondary}', ccrAccent: '${C.ccrAccent}', ccrDim: '${C.ccrDim}',
+    mirPrimary: '${C.mirPrimary}', mirSecondary: '${C.mirSecondary}', mirAccent: '${C.mirAccent}', mirDim: '${C.mirDim}',
+    defPrimary: '${C.defPrimary}', defDim: '${C.defDim}',
+};
+
+// Splash screens for each provider
+const splashScreens = {
+    zai: () => {
+        console.log('');
+        console.log(\`\${C.zaiPrimary}    ███████╗       █████╗ ██╗\${C.reset}\`);
+        console.log(\`\${C.zaiPrimary}    ╚══███╔╝      ██╔══██╗██║\${C.reset}\`);
+        console.log(\`\${C.zaiSecondary}      ███╔╝       ███████║██║\${C.reset}\`);
+        console.log(\`\${C.zaiSecondary}     ███╔╝    \${C.zaiAccent}██╗\${C.zaiSecondary} ██╔══██║██║\${C.reset}\`);
+        console.log(\`\${C.zaiAccent}    ███████╗  ╚═╝ ██║  ██║██║\${C.reset}\`);
+        console.log(\`\${C.zaiAccent}    ╚══════╝      ╚═╝  ╚═╝╚═╝\${C.reset}\`);
+        console.log('');
+        console.log(\`\${C.zaiDim}    ━━━━━━━━━━\${C.zaiPrimary}◆\${C.zaiDim}━━━━━━━━━━\${C.reset}\`);
+        console.log(\`\${C.zaiSecondary}      GLM Coding Plan\${C.reset}\`);
+        console.log('');
+    },
+    minimax: () => {
+        console.log('');
+        console.log(\`\${C.mmPrimary}    ███╗   ███╗██╗███╗   ██╗██╗███╗   ███╗ █████╗ ██╗  ██╗\${C.reset}\`);
+        console.log(\`\${C.mmPrimary}    ████╗ ████║██║████╗  ██║██║████╗ ████║██╔══██╗╚██╗██╔╝\${C.reset}\`);
+        console.log(\`\${C.mmSecondary}    ██╔████╔██║██║██╔██╗ ██║██║██╔████╔██║███████║ ╚███╔╝\${C.reset}\`);
+        console.log(\`\${C.mmSecondary}    ██║╚██╔╝██║██║██║╚██╗██║██║██║╚██╔╝██║██╔══██║ ██╔██╗\${C.reset}\`);
+        console.log(\`\${C.mmAccent}    ██║ ╚═╝ ██║██║██║ ╚████║██║██║ ╚═╝ ██║██║  ██║██╔╝ ██╗\${C.reset}\`);
+        console.log(\`\${C.mmAccent}    ╚═╝     ╚═╝╚═╝╚═╝  ╚═══╝╚═╝╚═╝     ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝\${C.reset}\`);
+        console.log('');
+        console.log(\`\${C.mmDim}    ━━━━━━━━━━━━━━━━━━\${C.mmPrimary}◆\${C.mmDim}━━━━━━━━━━━━━━━━━━\${C.reset}\`);
+        console.log(\`\${C.mmSecondary}           MiniMax-M2.1 \${C.mmDim}━\${C.mmSecondary} AGI for All\${C.reset}\`);
+        console.log('');
+    },
+    openrouter: () => {
+        console.log('');
+        console.log(\`\${C.orPrimary}     ██████╗ ██████╗ ███████╗███╗   ██╗\${C.reset}\`);
+        console.log(\`\${C.orPrimary}    ██╔═══██╗██╔══██╗██╔════╝████╗  ██║\${C.reset}\`);
+        console.log(\`\${C.orSecondary}    ██║   ██║██████╔╝█████╗  ██╔██╗ ██║\${C.reset}\`);
+        console.log(\`\${C.orSecondary}    ██║   ██║██╔═══╝ ██╔══╝  ██║╚██╗██║\${C.reset}\`);
+        console.log(\`\${C.orAccent}    ╚██████╔╝██║     ███████╗██║ ╚████║\${C.reset}\`);
+        console.log(\`\${C.orAccent}     ╚═════╝ ╚═╝     ╚══════╝╚═╝  ╚═══╝\${C.reset}\`);
+        console.log(\`\${C.orPrimary}    ██████╗  ██████╗ ██╗   ██╗████████╗███████╗██████╗\${C.reset}\`);
+        console.log(\`\${C.orPrimary}    ██╔══██╗██╔═══██╗██║   ██║╚══██╔══╝██╔════╝██╔══██╗\${C.reset}\`);
+        console.log(\`\${C.orSecondary}    ██████╔╝██║   ██║██║   ██║   ██║   █████╗  ██████╔╝\${C.reset}\`);
+        console.log(\`\${C.orSecondary}    ██╔══██╗██║   ██║██║   ██║   ██║   ██╔══╝  ██╔══██╗\${C.reset}\`);
+        console.log(\`\${C.orAccent}    ██║  ██║╚██████╔╝╚██████╔╝   ██║   ███████╗██║  ██║\${C.reset}\`);
+        console.log(\`\${C.orAccent}    ╚═╝  ╚═╝ ╚═════╝  ╚═════╝    ╚═╝   ╚══════╝╚═╝  ╚═╝\${C.reset}\`);
+        console.log('');
+        console.log(\`\${C.orDim}    ━━━━━━━━━━━━━\${C.orPrimary}◆\${C.orDim}━━━━━━━━━━━━━\${C.reset}\`);
+        console.log(\`\${C.orSecondary}      One API \${C.orDim}━\${C.orSecondary} Any Model\${C.reset}\`);
+        console.log('');
+    },
+    ccrouter: () => {
+        console.log('');
+        console.log(\`\${C.ccrPrimary}     ██████╗ ██████╗██████╗  ██████╗ ██╗   ██╗████████╗███████╗██████╗\${C.reset}\`);
+        console.log(\`\${C.ccrPrimary}    ██╔════╝██╔════╝██╔══██╗██╔═══██╗██║   ██║╚══██╔══╝██╔════╝██╔══██╗\${C.reset}\`);
+        console.log(\`\${C.ccrSecondary}    ██║     ██║     ██████╔╝██║   ██║██║   ██║   ██║   █████╗  ██████╔╝\${C.reset}\`);
+        console.log(\`\${C.ccrSecondary}    ██║     ██║     ██╔══██╗██║   ██║██║   ██║   ██║   ██╔══╝  ██╔══██╗\${C.reset}\`);
+        console.log(\`\${C.ccrAccent}    ╚██████╗╚██████╗██║  ██║╚██████╔╝╚██████╔╝   ██║   ███████╗██║  ██║\${C.reset}\`);
+        console.log(\`\${C.ccrAccent}     ╚═════╝ ╚═════╝╚═╝  ╚═╝ ╚═════╝  ╚═════╝    ╚═╝   ╚══════╝╚═╝  ╚═╝\${C.reset}\`);
+        console.log('');
+        console.log(\`\${C.ccrDim}    ━━━━━━━━━━━━━━━━\${C.ccrPrimary}◆\${C.ccrDim}━━━━━━━━━━━━━━━━\${C.reset}\`);
+        console.log(\`\${C.ccrSecondary}      Claude Code Router \${C.ccrDim}━\${C.ccrSecondary} Any Model\${C.reset}\`);
+        console.log('');
+    },
+    mirror: () => {
+        console.log('');
+        console.log(\`\${C.mirPrimary}    ███╗   ███╗██╗██████╗ ██████╗  ██████╗ ██████╗\${C.reset}\`);
+        console.log(\`\${C.mirPrimary}    ████╗ ████║██║██╔══██╗██╔══██╗██╔═══██╗██╔══██╗\${C.reset}\`);
+        console.log(\`\${C.mirSecondary}    ██╔████╔██║██║██████╔╝██████╔╝██║   ██║██████╔╝\${C.reset}\`);
+        console.log(\`\${C.mirSecondary}    ██║╚██╔╝██║██║██╔══██╗██╔══██╗██║   ██║██╔══██╗\${C.reset}\`);
+        console.log(\`\${C.mirAccent}    ██║ ╚═╝ ██║██║██║  ██║██║  ██║╚██████╔╝██║  ██║\${C.reset}\`);
+        console.log(\`\${C.mirAccent}    ╚═╝     ╚═╝╚═╝╚═╝  ╚═╝╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═╝\${C.reset}\`);
+        console.log('');
+        console.log(\`\${C.mirDim}    ━━━━━━━━━━━━\${C.mirAccent}◇\${C.mirDim}━━━━━━━━━━━━\${C.reset}\`);
+        console.log(\`\${C.mirSecondary}      Claude \${C.mirDim}━\${C.mirSecondary} Pure Reflection\${C.reset}\`);
+        console.log('');
+    },
+    default: (label) => {
+        console.log('');
+        console.log(\`\${C.defPrimary}    ██████╗ ██████╗   \${C.defDim}━━  M I R R O R\${C.reset}\`);
+        console.log(\`\${C.defPrimary}   ██╔════╝██╔════╝\${C.reset}\`);
+        console.log(\`\${C.defPrimary}   ██║     ██║     \${C.defDim}Claude Code Variants\${C.reset}\`);
+        console.log(\`\${C.defPrimary}   ██║     ██║     \${C.defDim}Custom Providers\${C.reset}\`);
+        console.log(\`\${C.defPrimary}   ╚██████╗╚██████╗\${C.reset}\`);
+        console.log(\`\${C.defPrimary}    ╚═════╝ ╚═════╝\${C.reset}\`);
+        console.log('');
+        if (label) console.log(\`        \${label}\`);
+        console.log('');
+    }
+};
+
+// Show splash screen if enabled
+const showSplash = env.CC_MIRROR_SPLASH === '1' && process.stdout.isTTY && !process.argv.includes('--output-format');
+if (showSplash) {
+    const style = env.CC_MIRROR_SPLASH_STYLE || 'default';
+    const label = env.CC_MIRROR_PROVIDER_LABEL;
+    if (splashScreens[style]) {
+        splashScreens[style]();
+    } else {
+        splashScreens.default(label);
+    }
+}
+
+// Dynamic team name based on project folder
+if (env.CLAUDE_CODE_TEAM_MODE || env.TEAM) {
+    const cwd = process.cwd();
+    const folderName = path.basename(cwd);
+    if (env.TEAM) {
+        env.CLAUDE_CODE_TEAM_NAME = \`\${folderName}-\${env.TEAM}\`;
+    } else if (env.CLAUDE_CODE_TEAM_MODE) {
+        env.CLAUDE_CODE_TEAM_NAME = folderName;
+    }
+}
+
+const child = spawn('node', [cliPath, ...process.argv.slice(2)], {
+    stdio: 'inherit',
+    env: env
+});
+
+child.on('close', (code) => {
+    process.exit(code);
+});
+`;
+
+  const cmdContent = `@echo off
+node "%~dp0\\${path.basename(jsPath)}" %*
+`;
+
+  fs.writeFileSync(jsPath, jsContent);
+  fs.writeFileSync(cmdPath, cmdContent);
+};
+
 export type WrapperRuntime = 'native' | 'node';
 
 export const writeWrapper = (


### PR DESCRIPTION
## Summary

This PR adds Windows splash screen support so that all provider-specific colored ASCII art logos (Z.ai, MiniMax, OpenRouter, CCRouter, Mirror) now display correctly on Windows.

## Problem

The existing splash screens with colored ASCII art only work on macOS/Linux because they use bash heredoc syntax. Windows users see no splash screens.

## Solution

- Added \writeWindowsWrapper\ function in \wrapper.ts\ that generates a Node.js wrapper with all the colored splash screens
- Updated \WrapperStep.ts\ and \WrapperUpdateStep.ts\ to detect Windows (\process.platform === 'win32'\) and use the Windows-specific wrapper

## Features

- **All 5 providers supported**: Z.ai (gold), MiniMax (coral), OpenRouter (teal), CCRouter (blue), Mirror (silver)
- **Proper ANSI 256-color codes**: Uses \\\x1b[38;5;XXXm\ escape sequences that render correctly in Windows Terminal
- **Same look as Mac/Linux**: Windows users now see the exact same colored logos

## Testing

Tested on Windows 11 with Windows Terminal - colors render correctly.

## Screenshots

The colored splash screens match the existing ones shown in the README.