### PR TITLE
fix: patch incompatible JavaScript template expressions for Claude Code 2.1.1

### DIFF
--- a/src/core/variant-builder/steps/TeamModeStep.ts
+++ b/src/core/variant-builder/steps/TeamModeStep.ts
@@ -17,27 +17,146 @@ import type { BuildContext, BuildStep } from '../types.js';
 const TEAM_MODE_DISABLED = 'function Uq(){return!1}';
 const TEAM_MODE_ENABLED = 'function Uq(){return!0}';
 
+// Regex patterns for patching incompatible template expressions in Claude Code 2.1.1
+const REGEX_TASK_MANAGEMENT =
+  /\$\{AVAILABLE_TOOLS_SET\.has\(TODO_TOOL_OBJECT\.name\)\?`# Task Management[\s\S]*?`:""\}/g;
+const REGEX_ASK_QUESTION = /\$\{AVAILABLE_TOOLS_SET\.has\(ASKUSERQUESTION_TOOL_NAME\)\?`[\s\S]*?`:""\}/g;
+const REGEX_TODO_TOOL =
+  /\$\{AVAILABLE_TOOLS_SET\.has\(TODO_TOOL_OBJECT\.name\)\?`Use the \$\{TODO_TOOL_OBJECT\.name\} tool to plan the task if required`:""\}/g;
+const REGEX_ASKQUESTION_TOOL =
+  /\$\{AVAILABLE_TOOLS_SET\.has\(ASKUSERQUESTION_TOOL_NAME\)\?`Use the \$\{ASKUSERQUESTION_TOOL_NAME\} tool to ask questions, clarify and gather information as needed.`:""\}/g;
+const REGEX_TOOL_USAGE =
+  /# Tool usage policy\$\{AVAILABLE_TOOLS_SET\.has\(TASK_TOOL_NAME\)\?`[\s\S]*?\$\{AGENT_TOOL_USAGE_NOTES\}`:""\}/g;
+const REGEX_WEBFETCH_TOOL =
+  /\$\{AGENT_TOOL_USAGE_NOTES\}`:""\}\$\{AVAILABLE_TOOLS_SET\.has\(WEBFETCH_TOOL_NAME\)\?`[\s\S]*?`:""\}/g;
+const REGEX_CATCH_ALL = /\$\{AVAILABLE_TOOLS_SET\.has\([^)]+\)\?`[\s\S]*?`:""\}/g;
+
+// Static replacements for incompatible template expressions
+const REPLACEMENT_TASK_MANAGEMENT = `# Task Management
+
+You have access to Task* tools to help you manage and plan tasks. Use these tools VERY frequently to ensure that you are tracking your tasks and giving the user visibility into your progress.
+
+It is critical that you mark todos as completed as soon as you are done with a task.`;
+
+const REPLACEMENT_ASK_QUESTION = `# Asking questions as you work
+
+You have access to the AskUserQuestion tool to ask the user questions when you need clarification, want to validate assumptions, or need to make a decision you're unsure about.`;
+
+const REPLACEMENT_TOOL_USAGE = `# Tool usage policy
+- When doing file search, prefer to use the Task tool in order to reduce context usage.
+- You should proactively use the Task tool with specialized agents when the task at hand matches the agent's description.`;
+
+const isVersionIncompatible211 = (version: string): boolean => {
+  return version === '2.1.1';
+};
+
+const patchProblematicPromptExpressions = (systemPromptsDir: string): void => {
+  if (!fs.existsSync(systemPromptsDir)) return;
+
+  const files = fs.readdirSync(systemPromptsDir).filter((f) => f.endsWith('.md'));
+
+  for (const file of files) {
+    const filePath = path.join(systemPromptsDir, file);
+    let content: string;
+    try {
+      content = fs.readFileSync(filePath, 'utf8');
+    } catch {
+      console.warn(`Warning: Could not read prompt file: ${filePath}`);
+      continue;
+    }
+
+    let modified = false;
+
+    let before = content;
+    content = content.replace(REGEX_TASK_MANAGEMENT, REPLACEMENT_TASK_MANAGEMENT);
+    modified = modified || content !== before;
+
+    before = content;
+    content = content.replace(REGEX_ASK_QUESTION, REPLACEMENT_ASK_QUESTION);
+    modified = modified || content !== before;
+
+    before = content;
+    content = content.replace(REGEX_TODO_TOOL, 'Use the TodoWrite tool to plan the task if required');
+    modified = modified || content !== before;
+
+    before = content;
+    content = content.replace(
+      REGEX_ASKQUESTION_TOOL,
+      'Use the AskUserQuestion tool to ask questions, clarify and gather information as needed.'
+    );
+    modified = modified || content !== before;
+
+    before = content;
+    content = content.replace(REGEX_TOOL_USAGE, REPLACEMENT_TOOL_USAGE);
+    modified = modified || content !== before;
+
+    before = content;
+    content = content.replace(REGEX_WEBFETCH_TOOL, '');
+    modified = modified || content !== before;
+
+    before = content;
+    content = content.replace(REGEX_CATCH_ALL, '');
+    modified = modified || content !== before;
+
+    if (modified) {
+      try {
+        fs.writeFileSync(filePath, content);
+      } catch {
+        console.warn(`Warning: Could not write prompt file: ${filePath}`);
+      }
+    }
+  }
+};
+
 export class TeamModeStep implements BuildStep {
   name = 'TeamMode';
 
   private shouldEnableTeamMode(ctx: BuildContext): boolean {
-    // Enable if explicitly requested via params OR if provider defaults to team mode
     return Boolean(ctx.params.enableTeamMode) || Boolean(ctx.provider.enablesTeamMode);
+  }
+
+  private getClaudeVersion(paths: { npmDir: string }): string {
+    try {
+      const packageJsonPath = path.join(paths.npmDir, 'node_modules', '@anthropic-ai', 'claude-code', 'package.json');
+      if (fs.existsSync(packageJsonPath)) {
+        const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+        return pkg.version || '';
+      }
+    } catch {
+      // ignore
+    }
+    return '';
   }
 
   execute(ctx: BuildContext): void {
     if (!this.shouldEnableTeamMode(ctx)) return;
+
+    const version = this.getClaudeVersion(ctx.paths);
+    const needsPromptPatch = isVersionIncompatible211(version);
+
+    if (needsPromptPatch) {
+      ctx.state.notes.push(`Applying prompt compatibility fixes for Claude Code ${version}`);
+    }
+
     ctx.report('Enabling team mode...');
-    this.patchCli(ctx);
+    this.patchCli(ctx, needsPromptPatch);
   }
 
   async executeAsync(ctx: BuildContext): Promise<void> {
     if (!this.shouldEnableTeamMode(ctx)) return;
+
+    const version = this.getClaudeVersion(ctx.paths);
+    const needsPromptPatch = isVersionIncompatible211(version);
+
+    if (needsPromptPatch) {
+      await ctx.report(`Applying prompt compatibility fixes for Claude Code ${version}`);
+    }
+
     await ctx.report('Enabling team mode...');
-    this.patchCli(ctx);
+    this.patchCli(ctx, needsPromptPatch);
   }
 
-  private patchCli(ctx: BuildContext): void {
+  private patchCli(ctx: BuildContext, needsPromptPatch: boolean): void {
     const { state, paths } = ctx;
 
     // Find cli.js path
@@ -130,6 +249,12 @@ export class TeamModeStep implements BuildStep {
     const copiedFiles = copyTeamPackPrompts(systemPromptsDir);
     if (copiedFiles.length > 0) {
       state.notes.push(`Team pack prompts installed (${copiedFiles.join(', ')})`);
+    }
+
+    // Patch problematic template expressions for Claude Code 2.1.1
+    if (needsPromptPatch) {
+      patchProblematicPromptExpressions(systemPromptsDir);
+      state.notes.push('Prompt compatibility patches applied for 2.1.1');
     }
 
     // Configure TweakCC toolset to block TodoWrite


### PR DESCRIPTION
## Summary

Fixes the `EJ.has is not a function` error that occurs when using team mode with Claude Code 2.1.1.

## Root Cause

Claude Code 2.1.1 changed internal variable names during minification. The system prompts contained JavaScript template expressions like `${AVAILABLE_TOOLS_SET.has(...)` which worked in earlier versions but fail in 2.1.1 where `AVAILABLE_TOOLS_SET` was minified to `EJ` but is no longer a Set with a `.has()` method.

## Solution

This fix detects Claude Code 2.1.1 and automatically patches the problematic template expressions in system prompts, replacing them with static content that works across all versions.

## Changes

- Extract regex patterns to named constants for better maintainability
- Add explicit type annotations for better TypeScript strict mode support
- Add error handling with `console.warn` for file read/write failures
- Improve code readability with descriptive constant names
- Use reliable modified flag logic: compare content before/after each replacement instead of using `content.includes()` which can be unreliable

## Testing

The fix has been verified to work with Claude Code 2.1.1 - team mode is now enabled without the `EJ.has is not a function` error.

Fixes: numman-ali/cc-mirror#27