### PR TITLE
feat: prevent wrapper command collisions + add --prefix (non-breaking)

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -11,6 +11,8 @@ export interface ParsedArgs {
   ['prompt-pack-mode']?: string;
   ['no-skill-install']?: boolean;
   ['skill-update']?: boolean;
+  prefix?: string;
+  ['allow-collision']?: boolean;
   ['shell-env']?: boolean;
   ['no-shell-env']?: boolean;
   ['tweakcc-stdio']?: string;

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -34,6 +34,7 @@ COMMANDS
 
 OPTIONS (create/quick)
   --name <name>                Variant name (becomes CLI command)
+  --prefix <value>             Prefix default variant name when --name is omitted
   --provider <name>            Provider: kimi | minimax | zai | openrouter | vercel | ollama | nanogpt | ccrouter | mirror | gatewayz
   --api-key <key>              Provider API key
   --auth-token <token>         Alias for --api-key (auth-token providers)
@@ -52,6 +53,7 @@ OPTIONS (advanced)
   --bin-dir <path>             Wrapper install dir (default: ${DEFAULT_BIN_DIR})
   --no-tweak                   Skip tweakcc theming
   --no-prompt-pack             Skip provider prompt pack
+  --allow-collision            Allow wrapper command name collisions (unsafe)
   --shell-env                  Write env vars to shell profile
   --verbose                    Show full tweakcc output during update
   --json                       Machine-readable output (list/doctor)

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -18,6 +18,7 @@ import type {
 
 export { DEFAULT_ROOT, DEFAULT_BIN_DIR, DEFAULT_CLAUDE_VERSION, DEFAULT_CLAUDE_NATIVE_CACHE_DIR };
 export { expandTilde } from './paths.js';
+export { detectCommandCollision } from './paths.js';
 
 export const createVariant = (params: CreateVariantParams): CreateVariantResult => {
   return new VariantBuilder(false).build(params);

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import os from 'node:os';
 import path from 'node:path';
@@ -41,4 +42,54 @@ export const commandExists = (cmd: string): boolean => {
     encoding: 'utf8',
   });
   return result.status === 0 && result.stdout.trim().length > 0;
+};
+
+export interface CommandCollisionCheck {
+  wrapperPath: string;
+  wrapperExists: boolean;
+  binDirOnPath: boolean;
+  resolvedCommandPath: string | null;
+  pathConflicts: boolean;
+  hasCollision: boolean;
+}
+
+const normalizeFsPath = (input: string): string => {
+  const normalized = path.normalize(input);
+  return isWindows ? normalized.toLowerCase() : normalized;
+};
+
+export const resolveCommandPath = (cmd: string): string | null => {
+  const result = spawnSync(process.platform === 'win32' ? 'where' : 'which', [cmd], {
+    encoding: 'utf8',
+  });
+  if (result.status !== 0 || !result.stdout) return null;
+  const firstLine = result.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean);
+  return firstLine || null;
+};
+
+export const detectCommandCollision = (name: string, binDir: string): CommandCollisionCheck => {
+  const resolvedBin = expandTilde(binDir) ?? binDir;
+  const wrapperPath = getWrapperPath(resolvedBin, name);
+  const wrapperExists = fs.existsSync(wrapperPath);
+  const pathEntries = (process.env.PATH || '')
+    .split(path.delimiter)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  const normalizedResolvedBin = normalizeFsPath(resolvedBin);
+  const binDirOnPath = pathEntries.some((entry) => normalizeFsPath(entry) === normalizedResolvedBin);
+  const resolvedCommandPath = resolveCommandPath(name);
+  const pathConflicts = Boolean(
+    binDirOnPath && resolvedCommandPath && normalizeFsPath(resolvedCommandPath) !== normalizeFsPath(wrapperPath)
+  );
+  return {
+    wrapperPath,
+    wrapperExists,
+    binDirOnPath,
+    resolvedCommandPath,
+    pathConflicts,
+    hasCollision: wrapperExists || pathConflicts,
+  };
 };

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -61,6 +61,8 @@ export interface CreateVariantParams {
   shellEnv?: boolean;
   skillUpdate?: boolean;
   tweakccStdio?: 'pipe' | 'inherit';
+  /** Allow wrapper command name collisions (unsafe). */
+  allowCollision?: boolean;
   /** Callback for progress updates during installation */
   onProgress?: ProgressCallback;
 }

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -63,6 +63,13 @@ test('parseArgs handles key value arguments', () => {
   assert.equal(result.name, 'my-variant');
 });
 
+test('parseArgs handles --prefix and --allow-collision flags', () => {
+  const result = parseArgs(['--provider', 'kimi', '--prefix', 'cc', '--allow-collision']);
+  assert.equal(result.provider, 'kimi');
+  assert.equal(result.prefix, 'cc');
+  assert.equal(result['allow-collision'], true);
+});
+
 test('parseArgs handles boolean flags with trailing value', () => {
   // Parser treats consecutive flags as key-value pairs when no = is used
   // This tests that the parser correctly handles the case where a flag

--- a/test/core/paths.test.ts
+++ b/test/core/paths.test.ts
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+import { cleanup, makeTempDir } from '../helpers/index.js';
+import { detectCommandCollision, getWrapperPath, resolveCommandPath } from '../../src/core/paths.js';
+
+test('resolveCommandPath returns null for unknown command', () => {
+  const resolved = resolveCommandPath('cc_mirror_command_that_should_not_exist_12345');
+  assert.equal(resolved, null);
+});
+
+test('detectCommandCollision reports wrapper collisions', () => {
+  const binDir = makeTempDir();
+  try {
+    const wrapperPath = getWrapperPath(binDir, 'samplecmd');
+    fs.writeFileSync(wrapperPath, '#!/usr/bin/env bash\necho hello\n');
+    const result = detectCommandCollision('samplecmd', binDir);
+    assert.equal(result.wrapperExists, true);
+    assert.equal(result.hasCollision, true);
+  } finally {
+    cleanup(binDir);
+  }
+});
+
+test('detectCommandCollision reports path conflicts for existing system commands', () => {
+  const resolvedNode = resolveCommandPath('node');
+  if (!resolvedNode) return;
+
+  const binDir = makeTempDir();
+  try {
+    const result = detectCommandCollision('node', binDir);
+    assert.equal(result.binDirOnPath, false);
+    assert.equal(result.pathConflicts, false);
+    assert.equal(result.hasCollision, false);
+  } finally {
+    cleanup(binDir);
+  }
+});
+
+test('detectCommandCollision marks path conflict when bin dir is on PATH', () => {
+  const resolvedNode = resolveCommandPath('node');
+  if (!resolvedNode) return;
+
+  const binDir = makeTempDir();
+  const previousPath = process.env.PATH;
+  try {
+    process.env.PATH = `${binDir}${process.platform === 'win32' ? ';' : ':'}${previousPath || ''}`;
+    const result = detectCommandCollision('node', binDir);
+    assert.equal(result.binDirOnPath, true);
+    assert.equal(result.pathConflicts, true);
+    assert.equal(result.hasCollision, true);
+  } finally {
+    process.env.PATH = previousPath;
+    cleanup(binDir);
+  }
+});


### PR DESCRIPTION
## Summary
Prevent accidental shadowing/overwriting of existing CLI commands by cc-mirror wrapper scripts.

This PR is non-breaking: no provider defaults are changed. It adds safe guards and an opt-in naming helper.

## Changes
- Core: detect wrapper command name collisions and block creation by default
- CLI: add `--prefix <value>` (applies when `--name` is omitted)
- CLI/TUI: fail fast with a clear error message on collision
- Escape hatch: `--allow-collision` to bypass (unsafe)
- Tests: add coverage for collision detection and new CLI args

## Why
Users can have existing tools named like providers (e.g. `kimi`), and creating a variant with the same name can shadow or overwrite the original command on `$PATH`.

## Notes
Collision detection considers `$PATH` conflicts only when the target `binDir` is actually on `$PATH`, plus the existing-wrapper-file case.
